### PR TITLE
Fix offset aware timestamps

### DIFF
--- a/src/grpc_accesslog/_server.py
+++ b/src/grpc_accesslog/_server.py
@@ -80,7 +80,7 @@ class AccessLogInterceptor(ServerInterceptor):
         """
         start = datetime.now(timezone.utc)
         response = method(request, context)
-        end = datetime.now()
+        end = datetime.now(timezone.utc)
 
         log_context = LogContext(
             context,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,12 @@
 """Server interceptor tests."""
 import logging
+import re
 from unittest.mock import Mock
 
 from pytest import LogCaptureFixture
 
 from grpc_accesslog import AccessLogInterceptor
+from grpc_accesslog import handlers
 
 
 def test_default_handlers() -> None:
@@ -31,3 +33,21 @@ def test_intercept(caplog: LogCaptureFixture) -> None:
     interceptor.intercept(Mock(), Mock(), Mock(), "/abc/Test")
 
     assert "this that" in caplog.text
+
+
+def test_rtt_handler_succeeds(caplog: LogCaptureFixture) -> None:
+    """Test RTT handler should not raise errors through interceptor."""
+    caplog.set_level(logging.INFO, logger="root")
+
+    interceptor = AccessLogInterceptor(
+        name="root",
+        handlers=(
+            lambda _: "this",
+            handlers.rtt_ms,
+        ),
+        propagate=True,
+    )
+
+    interceptor.intercept(Mock(), Mock(), Mock(), "/abc/Test")
+
+    assert re.match(r"^.*this \d+", caplog.text)


### PR DESCRIPTION
Fixes #267 

Start time was offset aware, end time was not, breaking `rtt_ms`. Fixes and adds quick test.