### PR TITLE
Support continuation returning none

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grpc-accesslog"
-version = "0.2.0"
+version = "0.2.1"
 description = "gRPC Access Log"
 authors = ["Michael Morgan <git@morgan83.com>"]
 license = "MIT"


### PR DESCRIPTION
Missed the case from https://github.com/grpc/grpc/issues/18191#issuecomment-574735994 where we are called when our wrapping continuation returned None into our handler param.