### PR TITLE
Use public methods for gRPC status code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ show_error_codes = true
 show_error_context = true
 
 [[tool.mypy.overrides]]
-module = [ "grpc" ]
+module = [ "grpc", "grpc.aio" ]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/grpc_accesslog/_async_server.py
+++ b/src/grpc_accesslog/_async_server.py
@@ -7,6 +7,7 @@ from typing import Awaitable
 from typing import Callable
 
 import grpc
+import grpc.aio
 
 from ._server import AccessLogger
 from ._server import _wrap_rpc_behavior

--- a/src/grpc_accesslog/handlers.py
+++ b/src/grpc_accesslog/handlers.py
@@ -83,11 +83,8 @@ def status(context: LogContext) -> str:
         str: gRPC status code name
     """
     code = grpc.StatusCode.OK.name
-    # TODO gRPC status code is not exposed publicly anywhere in the server
-    # interceptor's context
-    if getattr(context.server_context, "_state", None):
-        if context.server_context._state.code:  # type: ignore
-            code = context.server_context._state.code.name  # type: ignore
+    if context.server_context.code():
+        code = context.server_context.code().name
 
     return str(code)
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -18,9 +18,7 @@ def servicer_context() -> Mock:
         grpc.ServicerContext,
         name="ServicerContext",
         peer=Mock(return_value="ipv4:192.168.0.1:58111"),
-        _state=Mock(
-            code=grpc.StatusCode.NOT_FOUND,
-        ),
+        code=Mock(return_value=grpc.StatusCode.NOT_FOUND),
     )
 
     return context


### PR DESCRIPTION
Code and details were added (back?) into ServicerContext since this was originally written. Use them instead of digging into private `_state`. The `_state` attr is also not available in aio ServicerContext while public code and details are.